### PR TITLE
python-cairo missing from Readme

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,7 +12,7 @@ Pixelflut (python)
 
 Gevent and pygame based python implementation. easier to hack with, but a bit slow. Not recommended for more than 20 players.
 
-    sudo aptitude install python-gevent python-pygame
+    sudo aptitude install python-gevent python-pygame python-cairo
     cd pixelflut
     mkdir save
     python pixelflut.py brain.py

--- a/README.txt
+++ b/README.txt
@@ -14,6 +14,7 @@ Gevent and pygame based python implementation. easier to hack with, but a bit sl
 
     sudo aptitude install python-gevent python-pygame
     cd pixelflut
+    mkdir save
     python pixelflut.py brain.py
 
 Pixelwar (java)


### PR DESCRIPTION
On a Raspberry Pi, setting up pixelflut also required installation of python-cairo.