### PR TITLE
Fix/python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,28 @@ This repository contains multiple implementations of the pixelflut protocol. Pul
 
 ### `/pixelflut` (python server)
 
-Server written in Python, based on gevent and pygame. Easy to hack with, but a bit slow. In fact, it was slowed down on purpose to be more fair and encourage smart drawing techniques instead of image spamming. Perfect for small groups.
+Server written in Python2, based on gevent and pygame. Easy to hack with, but a bit slow. In fact, it was slowed down on purpose to be more fair and encourage smart drawing techniques instead of image spamming. Perfect for small groups.
 
     cd pixelflut
     sudo apt-get install python-gevent python-pygame python-cairo
     mkdir save
-    python pixelflut.py brain.py
+    python2 pixelflut.py brain.py
+
+Alternatively use `pip2` and a virtual environemnt for cleaner dependecy management.
+
+    cd pixelflut
+
+    pip2 install virtualenv
+    python2 -m virtualenv venv
+
+    source venv/bin/activate
+    pip2 install -r requirements.txt
+    mkdir save
+    python2 pixelflut.py brain.py
+
+After exiting, deactivate the virtual environment
+
+    deactivate
 
 #### `/pixelwar` (java server)
 

--- a/pixelflut/requirements.txt
+++ b/pixelflut/requirements.txt
@@ -1,0 +1,6 @@
+gevent==21.12.0
+greenlet==1.1.2
+pycairo==1.18.2
+pygame==2.0.3
+zope.event==4.5.0
+zope.interface==5.4.0


### PR DESCRIPTION
The `/pixelfut` server is written in `python2`, which was officially [deprecated](https://www.python.org/doc/sunset-python-2/) in 2020. To encapsulate this deprecated software stack and to keep the system dependencies clean, I recommend to use a `virtual environment` and `pip2`.